### PR TITLE
Delegating Directional Movement to Input Components

### DIFF
--- a/Scenes/components/input_component.tscn
+++ b/Scenes/components/input_component.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://dx7lavirccmg7"]
+
+[ext_resource type="Script" uid="uid://cvwyl4qeknfvc" path="res://Scripts/components/input_component.gd" id="1_iajo6"]
+
+[node name="InputComponent" type="Node"]
+script = ExtResource("1_iajo6")

--- a/Scenes/player.tscn
+++ b/Scenes/player.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=88 format=3 uid="uid://cgwfwpy4sfg8r"]
+[gd_scene load_steps=89 format=3 uid="uid://cgwfwpy4sfg8r"]
 
 [ext_resource type="Script" uid="uid://bdq4h6iafclli" path="res://Scripts/player.gd" id="1_cvnsp"]
 [ext_resource type="Texture2D" uid="uid://d0djok8y1fmuk" path="res://Assets/Player/Player Front Sheet.png" id="2_6t5aa"]
@@ -10,6 +10,7 @@
 [ext_resource type="FontFile" uid="uid://lxeddhw7kru1" path="res://Assets/Font/ARCADECLASSIC.TTF" id="8_gymyn"]
 [ext_resource type="Texture2D" uid="uid://c4xvnv66nrhov" path="res://Assets/Icons/potion_02c.png" id="9_pu2lt"]
 [ext_resource type="Texture2D" uid="uid://c165g8lnh74xn" path="res://Assets/Icons/potion_02b.png" id="10_ukyrk"]
+[ext_resource type="PackedScene" uid="uid://dx7lavirccmg7" path="res://Scenes/components/input_component.tscn" id="11_gymyn"]
 
 [sub_resource type="CapsuleShape2D" id="CapsuleShape2D_vgqql"]
 
@@ -596,8 +597,9 @@ animations = [{
 "speed": 10.0
 }]
 
-[node name="Player" type="CharacterBody2D"]
+[node name="Player" type="CharacterBody2D" node_paths=PackedStringArray("input_component")]
 script = ExtResource("1_cvnsp")
+input_component = NodePath("InputComponent")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 shape = SubResource("CapsuleShape2D_vgqql")
@@ -831,5 +833,7 @@ grow_horizontal = 0
 grow_vertical = 2
 theme_override_fonts/font = ExtResource("8_gymyn")
 text = "1"
+
+[node name="InputComponent" parent="." instance=ExtResource("11_gymyn")]
 
 [connection signal="animation_finished" from="AnimatedSprite2D" to="." method="_on_animated_sprite_2d_animation_finished"]

--- a/Scripts/components/input_component.gd
+++ b/Scripts/components/input_component.gd
@@ -1,0 +1,12 @@
+class_name InputComponent
+extends Node
+
+# Stores current Horizontal input. -1 for Left, 1 for Right, 0 for no press
+var input_horizontal: float = 0
+# Stores current Vertical input. -1 for Up, 1 for Down, 0 for no press
+var input_vertical: float = 0
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta: float) -> void:
+	input_horizontal = Input.get_axis("ui_left", "ui_right")
+	input_vertical = Input.get_axis("ui_up", "ui_down")

--- a/Scripts/components/input_component.gd.uid
+++ b/Scripts/components/input_component.gd.uid
@@ -1,0 +1,1 @@
+uid://cvwyl4qeknfvc

--- a/Scripts/player.gd
+++ b/Scripts/player.gd
@@ -1,5 +1,10 @@
 extends CharacterBody2D
 
+@export_category("Nodes")
+# Component for listening to input
+@export var input_component: InputComponent
+
+@export_category("Settings")
 # Player movement speed
 @export var speed = 50
 
@@ -28,13 +33,7 @@ signal stamina_updated
 # ---------------------------------- Movement & Animations ---------------------------------------
 func _physics_process(delta):
 	# Get player input
-	var direction: Vector2
-	direction.x = Input.get_action_strength("ui_right") - Input.get_action_strength("ui_left")
-	direction.y = Input.get_action_strength("ui_down") - Input.get_action_strength("ui_up")
-	
-	# If input is digital, normalize it for diagonal movement
-	if abs(direction.x) == 1 and abs(direction.y) == 1:
-		direction = direction.normalized()
+	var direction = Vector2(input_component.input_horizontal, input_component.input_vertical)
 	
 	# Sprinting
 	if Input.is_action_pressed("ui_sprint"):

--- a/project.godot
+++ b/project.godot
@@ -19,7 +19,6 @@ config/icon="res://icon.svg"
 
 window/size/viewport_width=320
 window/size/viewport_height=180
-window/size/mode=2
 window/stretch/mode="viewport"
 
 [input]
@@ -66,3 +65,4 @@ ui_attack={
 [rendering]
 
 textures/canvas_textures/default_texture_filter=0
+2d/snap/snap_2d_transforms_to_pixel=true


### PR DESCRIPTION
- Moves the ui left, right, up and down to generic component that can be reused.
- Removed normalization for diagonal input. Seems to work just the same.